### PR TITLE
board: t3-gem-o1: Boot-files-changed

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -13,7 +13,7 @@
 /* Time synchronization URL (only used on eglfs QPA platform, URL must be HTTP) */
 #define TIME_URL                          "https://packages.t3gemstone.org/images/list.json?time_synchronization"
 
-#define BOOTIMG_URL                       "http://packages.t3gemstone.org/images/boot/%1/%2" // %1: boardName %2: fileName
+#define BOOTIMG_URL                       "https://packages.t3gemstone.org/images/boot/%1/%2" // %1: boardName %2: fileName
 
 /* Phone home the name of images downloaded for image popularity ranking */
 #define TELEMETRY_URL                     "https://gem-imager-stats.t3gemstone.org"

--- a/src/dfuthread.cpp
+++ b/src/dfuthread.cpp
@@ -6,18 +6,33 @@
 #include "dfuthread.h"
 #include "dfuwrapper.h"
 #include "config.h"
-#include "devicewrapper.h"
-#include "devicewrapperfatpartition.h"
 #include "downloadextractthread.h"
 #include <QFile>
 #include <QDebug>
 #include <QThread>
+#include <QCryptographicHash>
 #include <QCoreApplication>
+#include <QStandardPaths>
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include <QEventLoop>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
 
 DfuThread::DfuThread(const QByteArray &url, const QByteArray &localfilename,
-                     const QByteArray &expectedHash, QObject *parent)
+                     const QByteArray &expectedHash, const QByteArray &tiboot3Hash,
+                     const QByteArray &tisplHash, const QByteArray &ubootHash, QObject *parent)
     : DownloadExtractThread(url, localfilename, expectedHash, parent)
     , _tempImageFile(nullptr)
+    , _expectedTiboot3Hash(tiboot3Hash)
+    , _expectedTisplHash(tisplHash)
+    , _expectedUbootHash(ubootHash)
 {
     _suppressSuccessSignal = true;
     _ejectEnabled = false;
@@ -89,8 +104,8 @@ void DfuThread::run()
         _file.close();
     }
 
-    emit dfuProgress(38, tr("Extracting bootloader files from image..."));
-    if (!extractBootloaderFromImage()) return;
+    emit dfuProgress(38, tr("Fetching bootloader files..."));
+    if (!fetchBootloaderFiles()) return;
 
     emit dfuProgress(45, tr("Sending bootloader files..."));
     if (!sendBootloaderFiles()) return;
@@ -150,54 +165,113 @@ bool DfuThread::sendBootloaderFiles()
     return true;
 }
 
-bool DfuThread::extractBootloaderFromImage()
+bool DfuThread::fetchBootloaderFiles()
 {
-    QStringList fileNames = {"tiboot3.bin", "tispl.bin", "u-boot.img"};
+    QString listUrlStr = QString(BOOTIMG_URL).arg("t3-gem-o1").arg("list.json");
+    
+    emit dfuProgress(40, tr("Fetching bootloader list..."));
 
-    if (_file.isOpen())
-        _file.close();
+    QNetworkAccessManager manager;
+    QNetworkRequest request((QUrl(listUrlStr)));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    
+    QNetworkReply *reply = manager.get(request);
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
 
-    _file.setFileName(_tempImagePath.replace("\\", "/"));
-    if (!_file.open(QIODevice::ReadOnly)) {
-        emit error(tr("Failed to reopen image file: %1").arg(_file.errorString()));
-        return false;
-    }
-
-    try {
-        _file.seek(0);
-        DeviceWrapper dw(&_file);
-        DeviceWrapperFatPartition *fat = dw.fatPartition(1);
-
-        for (int i = 0; i < 3; i++) {
-            QByteArray data = fat->readFile(fileNames[i]);
-            if (data.isEmpty()) {
-                emit error(tr("Bootloader file not found in image: %1").arg(fileNames[i]));
-                return false;
-            }
-
-#ifdef Q_OS_WIN
-            QTemporaryFile tmp(QCoreApplication::applicationDirPath() + "/dfu_XXXXXX");
-#else
-            QTemporaryFile tmp;
-#endif
-            tmp.setAutoRemove(false);
-            if (!tmp.open()) {
-                emit error(tr("Failed to create temp file for %1").arg(fileNames[i]));
-                return false;
-            }
-
-            if (tmp.write(data) != data.size()) {
-                emit error(tr("Failed to write temp file for %1").arg(fileNames[i]));
-                return false;
-            }
-            tmp.close();
-            _bootloaderFiles[i] = tmp.fileName();
-            qDebug() << "Extracted" << fileNames[i] << ":" << data.size() << "bytes";
+    if (reply->error() == QNetworkReply::NoError) {
+        QByteArray jsonData = reply->readAll();
+        QJsonDocument doc = QJsonDocument::fromJson(jsonData);
+        QJsonObject root = doc.object();
+        QJsonArray filesArr = root["files"].toArray();
+        
+        for (int j = 0; j < filesArr.size(); ++j) {
+            QJsonObject fileObj = filesArr[j].toObject();
+            QString name = fileObj["name"].toString();
+            QByteArray hash = fileObj["sha256"].toString().toUtf8();
+            
+            if (name == "tiboot3.bin") _expectedTiboot3Hash = hash;
+            else if (name == "tispl.bin") _expectedTisplHash = hash;
+            else if (name == "u-boot.img") _expectedUbootHash = hash;
         }
+        qDebug() << "Updated bootloader hashes from list.json successfully.";
+    } else {
+        qDebug() << "Failed to fetch list.json from" << listUrlStr << ". Error:" << reply->errorString();
     }
-    catch (std::exception &e) {
-        emit error(tr("Error reading bootloader files from image: %1").arg(e.what()));
-        return false;
+    reply->deleteLater();
+
+    QStringList fileNames = {"tiboot3.bin", "tispl.bin", "u-boot.img"};
+    QList<QByteArray> expectedHashes = {_expectedTiboot3Hash, _expectedTisplHash, _expectedUbootHash};
+
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QDir::separator() + "bootloaders" + QDir::separator() + "t3-gem-o1";
+    QDir().mkpath(cacheDir);
+
+    for (int i = 0; i < 3; i++) {
+        QString fileName = fileNames[i];
+        QByteArray expectedHash = expectedHashes[i];
+#ifdef Q_OS_WIN
+        QTemporaryFile tmp(QCoreApplication::applicationDirPath() + "/dfu_XXXXXX");
+#else
+        QTemporaryFile tmp;
+#endif
+        tmp.setAutoRemove(false);
+        if (!tmp.open()) {
+            emit error(tr("Failed to create temp file for %1").arg(fileName));
+            return false;
+        }
+        tmp.close();
+
+        QString localCachePath = cacheDir + QDir::separator() + fileName;
+        QFileInfo fi(localCachePath);
+
+        QString urlstr;
+        bool useCache = false;
+
+        if (fi.exists() && fi.size() > 0) {
+            if (!expectedHash.isEmpty()) {
+                QFile f(localCachePath);
+                if (f.open(QIODevice::ReadOnly)) {
+                    QCryptographicHash hash(QCryptographicHash::Sha256);
+                    if (hash.addData(&f)) {
+                        if (hash.result().toHex() == expectedHash) {
+                            useCache = true;
+                        } else {
+                            qDebug() << "Cache hash mismatch for" << fileName << "expected:" << expectedHash << "got:" << hash.result().toHex();
+                        }
+                    }
+                    f.close();
+                }
+            } else {
+                useCache = true;
+            }
+        }
+
+        if (useCache) {
+            urlstr = QUrl::fromLocalFile(localCachePath).toString(QUrl::FullyEncoded);
+        } else {
+            urlstr = QString(BOOTIMG_URL).arg("t3-gem-o1").arg(fileName);
+            if (fi.exists()) {
+                QFile::remove(localCachePath);
+            }
+        }
+
+        DownloadThread dt(urlstr.toUtf8(), tmp.fileName().toUtf8(), expectedHash, true);
+        if (urlstr.startsWith("http")) {
+            dt.setCacheFile(localCachePath);
+        }
+
+        dt.start();
+        dt.wait();
+
+        if (!dt.successfull()) {
+            emit error(tr("Failed to download bootloader file: %1").arg(fileName));
+            QFile::remove(localCachePath); // clean up failed cache
+            return false;
+        }
+
+        _bootloaderFiles[i] = tmp.fileName();
+        qDebug() << "Ready" << fileName << "from" << urlstr;
     }
 
     return true;

--- a/src/dfuthread.h
+++ b/src/dfuthread.h
@@ -14,7 +14,7 @@ class DfuThread : public DownloadExtractThread
     Q_OBJECT
 public:
     explicit DfuThread(const QByteArray &url, const QByteArray &localfilename,
-                       const QByteArray &expectedHash, QObject *parent = nullptr);
+                       const QByteArray &expectedHash, const QByteArray &tiboot3Hash, const QByteArray &tisplHash, const QByteArray &ubootHash, QObject *parent = nullptr);
     ~DfuThread();
 
     bool isImage() override;
@@ -28,11 +28,14 @@ protected:
 
 private:
     QString _bootloaderFiles[3];
+    QByteArray _expectedTiboot3Hash;
+    QByteArray _expectedTisplHash;
+    QByteArray _expectedUbootHash;
     QTemporaryFile *_tempImageFile;
     QString _tempImagePath;
 
     bool runDfu(const QString &altSetting, const QString &filePath, bool resetAfter);
-    bool extractBootloaderFromImage();
+    bool fetchBootloaderFiles();
     bool sendBootloaderFiles();
     bool sendImageToRawemmc();
 };

--- a/src/i18n/gem-imager_ca.ts
+++ b/src/i18n/gem-imager_ca.ts
@@ -948,8 +948,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>S&apos;està escrivint... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>S&apos;està baixant... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_de.ts
+++ b/src/i18n/gem-imager_de.ts
@@ -1033,8 +1033,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Schreiben... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Herunterladen... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_en.ts
+++ b/src/i18n/gem-imager_en.ts
@@ -928,8 +928,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <source>Downloading... %1%</source>
+        <translation>Downloading... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_es.ts
+++ b/src/i18n/gem-imager_es.ts
@@ -948,8 +948,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Escribiendo... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Descargando... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_fr.ts
+++ b/src/i18n/gem-imager_fr.ts
@@ -1020,8 +1020,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Écriture... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Téléchargement... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_he.ts
+++ b/src/i18n/gem-imager_he.ts
@@ -952,8 +952,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>מתבצעת צריבה… %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>מתבצעת הורדה… %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_it.ts
+++ b/src/i18n/gem-imager_it.ts
@@ -977,8 +977,8 @@ Aggiungi sia &apos;gem-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Scrittura...%1</translation>
+        <source>Downloading... %1%</source>
+        <translation>Scaricamento...%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_ja.ts
+++ b/src/i18n/gem-imager_ja.ts
@@ -1024,8 +1024,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>書き込み中... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>ダウンロード中... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_ko.ts
+++ b/src/i18n/gem-imager_ko.ts
@@ -1028,8 +1028,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>쓰는 중... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>다운로드 중... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_nl.ts
+++ b/src/i18n/gem-imager_nl.ts
@@ -1036,8 +1036,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Schrijven... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Downloaden... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_pl.ts
+++ b/src/i18n/gem-imager_pl.ts
@@ -1033,8 +1033,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Zapisywanie... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Pobieranie... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_pt.ts
+++ b/src/i18n/gem-imager_pt.ts
@@ -952,8 +952,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>A gravar... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>A descarregar... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_ru.ts
+++ b/src/i18n/gem-imager_ru.ts
@@ -1016,8 +1016,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Запись... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Загрузка... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_sk.ts
+++ b/src/i18n/gem-imager_sk.ts
@@ -1028,8 +1028,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Zapisujem... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Sťahujem... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_sl.ts
+++ b/src/i18n/gem-imager_sl.ts
@@ -1016,8 +1016,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Pišem...%1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Prenašam...%1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_tr.ts
+++ b/src/i18n/gem-imager_tr.ts
@@ -902,8 +902,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Yazılıyor... %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>İndiriliyor... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1564"/>

--- a/src/i18n/gem-imager_uk.ts
+++ b/src/i18n/gem-imager_uk.ts
@@ -984,8 +984,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>Записування...%1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>Завантаження...%1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_zh-TW.ts
+++ b/src/i18n/gem-imager_zh-TW.ts
@@ -948,8 +948,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>正在寫入… %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>正在下載… %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/i18n/gem-imager_zh.ts
+++ b/src/i18n/gem-imager_zh.ts
@@ -948,8 +948,8 @@
     </message>
     <message>
         <location filename="../main.qml" line="1530"/>
-        <source>Writing... %1%</source>
-        <translation>正在写入…… %1%</translation>
+        <source>Downloading... %1%</source>
+        <translation>正在下载…… %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1541"/>

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -282,6 +282,14 @@
      return !_src.isEmpty() && !_dst.isEmpty();
  }
  
+void ImageWriter::setBootloaderHashes(const QByteArray &tiboot3Hash, const QByteArray &tisplHash, const QByteArray &ubootHash)
+{
+    _expectedTiboot3Hash = tiboot3Hash;
+    _expectedTisplHash = tisplHash;
+    _expectedUbootHash = ubootHash;
+}
+
+
  /* Start writing */
  void ImageWriter::startWrite()
  {
@@ -919,7 +927,7 @@ void ImageWriter::_startDfuThread()
 {
     QByteArray urlstr = _src.toString(_src.FullyEncoded).toLatin1();
 
-    DfuThread *dfuThread = new DfuThread(urlstr, _dst.toLatin1(), _expectedHash, this);
+    DfuThread *dfuThread = new DfuThread(urlstr, _dst.toLatin1(), _expectedHash, _expectedTiboot3Hash, _expectedTisplHash, _expectedUbootHash, this);
     _thread = dfuThread;
 
     connect(_thread, SIGNAL(success()), SLOT(onSuccess()));

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -44,6 +44,9 @@ public:
     /* Set URL to download from, and if known download length and uncompressed length */
     Q_INVOKABLE void setSrc(const QUrl &url, quint64 downloadLen = 0, quint64 extrLen = 0, QByteArray expectedHash = "", bool multifilesinzip = false, QString parentcategory = "", QString osname = "", QByteArray initFormat = "");
 
+    /* Set bootloader hashes from os_list.json */
+    Q_INVOKABLE void setBootloaderHashes(const QByteArray &tiboot3Hash, const QByteArray &tisplHash, const QByteArray &ubootHash);
+
     /* Set device to write to */
     Q_INVOKABLE void setDst(const QString &device, quint64 deviceSize = 0);
 
@@ -211,7 +214,7 @@ protected:
     QString _dst, _cacheFileName, _parentCategory, _osName, _currentLang, _currentLangcode, _currentKeyboard;
     QString _selSerPort, _selEthPort;
     QString _imageTargetBoard;
-    QByteArray _expectedHash, _cachedFileHash, _cmdline, _config, _firstrun, _cloudinit, _cloudinitNetwork, _geminit, _initFormat;
+    QByteArray _expectedHash, _expectedTiboot3Hash, _expectedTisplHash, _expectedUbootHash, _cachedFileHash, _cmdline, _config, _firstrun, _cloudinit, _cloudinitNetwork, _geminit, _initFormat;
     quint64 _downloadLen, _extrLen, _devLen, _dlnow, _verifynow;
     DriveListModel _drivelist;
     QQmlApplicationEngine *_engine;

--- a/src/main.qml
+++ b/src/main.qml
@@ -1519,7 +1519,7 @@ ApplicationWindow {
             if (progressText.text === qsTr("Cancelling..."))
                 return
 
-            progressText.text = qsTr("Writing... %1%").arg(Math.floor(newPos*100))
+            progressText.text = qsTr("Downloading... %1%").arg(Math.floor(newPos*100))
             progressBar.indeterminate = false
             progressBar.value = newPos
         }
@@ -2109,6 +2109,7 @@ ApplicationWindow {
             console.log("FINAL: board=", board, "imageType=", imageType, "distro=", distro, "variant=", variant)
 
             // DFU parameters are now handled through setSrc - URL contains all needed info
+            imageWriter.setBootloaderHashes(typeof(d.tiboot3_sha256) != "undefined" ? d.tiboot3_sha256 : "", typeof(d.tispl_sha256) != "undefined" ? d.tispl_sha256 : "", typeof(d.uboot_sha256) != "undefined" ? d.uboot_sha256 : "")
             imageWriter.setSrc(d.url, d.image_download_size, d.extract_size, typeof(d.extract_sha256) != "undefined" ? d.extract_sha256 : "", typeof(d.contains_multiple_files) != "undefined" ? d.contains_multiple_files : false, ospopup.categorySelected, d.name, typeof(d.init_format) != "undefined" ? d.init_format : "")
             osbutton.text = d.name
             ospopup.close()


### PR DESCRIPTION
Bootloader files are no longer extracted from the image; they are now fetched from a URL and cached locally. Fixed download progress status message shown as "Writing..." instead of "Downloading..." across all supported languages.  